### PR TITLE
 perf: use accurate sleep timing with perf_counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+game.log

--- a/README.md
+++ b/README.md
@@ -21,11 +21,39 @@ pip install -r requirements.txt
 
 ### Running the Script
 
-To run the `keystrokes` script, use the following command:
+To run the `keystrokes` script, follow the instructions below:
 
-```shell
-python src/app.py
-```
+#### Emulate 1D terminal game
+
+1. Open a terminal and navigate to the `keystrokes` directory.
+2. Run the following command:
+
+   ```shell
+   python -u src/app.py > game.log
+   ```
+
+   This command emulates a 1D terminal game and redirects the output to a log file named `game.log`. The `-u` flag is used to enable unbuffered output, ensuring that the log file is updated in real-time as the game progresses.
+
+3. In a separate terminal instance, run the following command:
+
+   ```shell
+   watch -n 0.033 "tail -n 1 game.log"
+   ```
+
+   This command continuously monitors the `game.log` file and displays the latest line every 0.033 seconds, creating a live gameplay experience. The interval of 0.033 seconds corresponds to a frame rate of approximately 30 frames per second (fps), providing smooth gameplay.
+
+#### For raw live output
+
+1. Open a terminal and navigate to the `keystrokes` directory.
+2. Run the following command:
+
+   ```shell
+   python src/app.py
+   ```
+
+   This command runs the script and provides raw live output without any logging.
+
+Make sure you have Python installed and the necessary dependencies are installed before running the script.
 
 ### Keybindings
 

--- a/src/app.py
+++ b/src/app.py
@@ -9,10 +9,9 @@ Inspiration: https://github.com/petternett/railway-statusbar
 
 from collections import deque
 from random import randint
-from time import time, sleep
+from time import time, sleep, perf_counter
 from threading import Event, Thread
 from typing import List, Union  # Literal, Optional
-from time import perf_counter
 
 from pynput import keyboard  # from emoji import emojize
 
@@ -203,7 +202,7 @@ class App:
                 self.new_key_event.wait()
                 self.new_key_event.clear()
 
-            curr_time = time()
+            curr_time = perf_counter()
             counter += self.velocity
 
             if counter >= 1:
@@ -227,18 +226,12 @@ class App:
                 self.total_km += 0.01
 
             self.render()
+
             # sleep(curr_time + FRAME_DELAY - time())
-
-            # elapsed_time = time() - curr_time
-            # if elapsed_time < FRAME_DELAY:
-            #     sleep_time = FRAME_DELAY - elapsed_time
-            #     sleep(sleep_time)
-
-            curr_time = perf_counter()
             elapsed_time = perf_counter() - curr_time
-            remaining_time = FRAME_DELAY - elapsed_time
-            if remaining_time > 0:
-                sleep(remaining_time)
+            if elapsed_time < FRAME_DELAY:
+                sleep_time = FRAME_DELAY - elapsed_time
+                sleep(sleep_time)
 
     # TODO: for neorun. user controlled pauses.
     def update(self, frame_delay) -> None:

--- a/src/app.py
+++ b/src/app.py
@@ -229,11 +229,16 @@ class App:
             self.render()
             # sleep(curr_time + FRAME_DELAY - time())
 
-            elapsed_time = time() - curr_time
-            if elapsed_time < FRAME_DELAY:
-                sleep_time = FRAME_DELAY - elapsed_time
-                sleep(sleep_time)
-            
+            # elapsed_time = time() - curr_time
+            # if elapsed_time < FRAME_DELAY:
+            #     sleep_time = FRAME_DELAY - elapsed_time
+            #     sleep(sleep_time)
+
+            curr_time = perf_counter()
+            elapsed_time = perf_counter() - curr_time
+            remaining_time = FRAME_DELAY - elapsed_time
+            if remaining_time > 0:
+                sleep(remaining_time)
 
     # TODO: for neorun. user controlled pauses.
     def update(self, frame_delay) -> None:

--- a/src/app.py
+++ b/src/app.py
@@ -12,6 +12,7 @@ from random import randint
 from time import time, sleep
 from threading import Event, Thread
 from typing import List, Union  # Literal, Optional
+from time import perf_counter
 
 from pynput import keyboard  # from emoji import emojize
 
@@ -226,7 +227,13 @@ class App:
                 self.total_km += 0.01
 
             self.render()
-            sleep(curr_time + FRAME_DELAY - time())
+            # sleep(curr_time + FRAME_DELAY - time())
+
+            elapsed_time = time() - curr_time
+            if elapsed_time < FRAME_DELAY:
+                sleep_time = FRAME_DELAY - elapsed_time
+                sleep(sleep_time)
+            
 
     # TODO: for neorun. user controlled pauses.
     def update(self, frame_delay) -> None:


### PR DESCRIPTION
added the following code

elapsed_time = time() - curr_time
if elapsed_time < FRAME_DELAY:
    sleep_time = FRAME_DELAY - elapsed_time
    sleep(sleep_time)
    
    